### PR TITLE
Prevent inadvertent set of wce guest feature

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -538,7 +538,7 @@ VirtIoHwInitialize(
     }
 
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_SEG_MAX)) {
-        guestFeatures |= (1ul << VIRTIO_BLK_F_WCACHE);
+        guestFeatures |= (1ul << VIRTIO_BLK_F_SEG_MAX);
     }
 
     if (CHECKBIT(adaptExt->features, VIRTIO_BLK_F_BLK_SIZE)) {


### PR DESCRIPTION
This change prevents VIRTIO_BLK_F_WCACHE guest feature from being set when VIRTIO_BLK_F_SEG_MAX was supposed to be set.

This was causing migrates to fail on RHEL 6.6 with error.
Features 0x20000250 unsupported. Allowed features: 0x71000454