### PR TITLE
balloon: fix memory statistics reporting

### DIFF
--- a/Balloon/app/memstat.cpp
+++ b/Balloon/app/memstat.cpp
@@ -93,6 +93,7 @@ BOOL CMemStat::Init()
 
 BOOL CMemStat::Update()
 {
+    SYSTEM_INFO sysinfo;
     MEMORYSTATUSEX statex = {sizeof(statex)};
     CComPtr< IEnumWbemClassObject > enumerator;
     CComPtr< IWbemClassObject > memory;
@@ -101,9 +102,11 @@ BOOL CMemStat::Update()
     HRESULT status  = S_OK;
     UINT idx = 0;
 
+    GetSystemInfo(&sysinfo);
+
     status = service->ExecQuery(
                              L"WQL",
-                             L"SELECT * FROM Win32_PerfFormattedData_PerfOS_Memory",
+                             L"SELECT * FROM Win32_PerfRawData_PerfOS_Memory",
                              WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
                              NULL,
                              &enumerator
@@ -139,7 +142,7 @@ BOOL CMemStat::Update()
             var_val.vt =  -1;
         }
         m_Stats[idx].tag = VIRTIO_BALLOON_S_SWAP_IN;
-        m_Stats[idx].val = (long)var_val;
+        m_Stats[idx].val = (__int64)var_val * sysinfo.dwPageSize;
         idx++;
 
         status = memory->Get( 
@@ -155,7 +158,7 @@ BOOL CMemStat::Update()
             var_val.vt =  -1;
         }
         m_Stats[idx].tag = VIRTIO_BALLOON_S_SWAP_OUT;
-        m_Stats[idx].val = (long)var_val;
+        m_Stats[idx].val = (__int64)var_val * sysinfo.dwPageSize;
         idx++;
 
         status = memory->Get( 


### PR DESCRIPTION
According to libvirt API reference, SWAP_IN, SWAP_OUT, MAJOR_FAULT, and
MINOR_FAULT must be reported as total numbers, not per second, as they
are now. Besides, SWAP_IN and SWAP_OUT are supposed to be in bytes, not
in pages. Virtio balloon driver for Linux follows these conventions,
while balloon service for Windows does not, which makes it inconvenient
to use these statistics when Windows and Linux VMs are running on the
same host.

This patch fixes this issue.

Signed-off-by: Vladimir Davydov <vdavydov@virtuozzo.com>