### PR TITLE
Balloon: some tweaks for guest statistics

### DIFF
--- a/Balloon/sys/memstat.c
+++ b/Balloon/sys/memstat.c
@@ -54,6 +54,7 @@ UpdateOverflowFreeCounter(PULARGE_INTEGER ofc, ULONG value)
 typedef enum _ULONG_COUNTER {
     _PageReadCount = 0,
     _DirtyPagesWriteCount,
+    _MappedPagesWriteCount,
     _PageReadIoCount,
     _PageFaultCount,
     _LastCounter
@@ -118,7 +119,8 @@ NTSTATUS GatherKernelStats(BALLOON_STAT stats[VIRTIO_BALLOON_S_NR])
 
     #define UpdateNoOverflow(x) UpdateOverflowFreeCounter(&Counters[_##x],perfInfo.##x)
     UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_SWAP_IN,  UpdateNoOverflow(PageReadCount) << PAGE_SHIFT);
-    UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_SWAP_OUT, UpdateNoOverflow(DirtyPagesWriteCount) << PAGE_SHIFT);
+    UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_SWAP_OUT,
+        (UpdateNoOverflow(DirtyPagesWriteCount) + UpdateNoOverflow(MappedPagesWriteCount)) << PAGE_SHIFT);
     UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_MAJFLT,   UpdateNoOverflow(PageReadIoCount));
     UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_MINFLT,   UpdateNoOverflow(PageFaultCount));
     UpdateStat(&stats[idx++], VIRTIO_BALLOON_S_MEMFREE,  U32_2_S64(perfInfo.AvailablePages) << PAGE_SHIFT);

--- a/viorng/cng/um/viorngum.c
+++ b/viorng/cng/um/viorngum.c
@@ -24,6 +24,8 @@
 
 #define STRICT
 #include <windows.h>
+#include <bcrypt.h>
+#include <bcrypt_provider.h>
 #include <initguid.h>
 #include <setupapi.h>
 #include <tchar.h>

--- a/viorng/cng/um/viorngum.vcxproj
+++ b/viorng/cng/um/viorngum.vcxproj
@@ -101,7 +101,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -120,7 +120,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -141,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -164,7 +164,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/viorng/coinstaller/viorngci.c
+++ b/viorng/coinstaller/viorngci.c
@@ -25,6 +25,7 @@
 #define STRICT
 #include <windows.h>
 #include <bcrypt.h>
+#include <bcrypt_provider.h>
 #include <setupapi.h>
 #include <tchar.h>
 

--- a/viorng/coinstaller/viorngci.vcxproj
+++ b/viorng/coinstaller/viorngci.vcxproj
@@ -78,13 +78,13 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -93,13 +93,13 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -110,15 +110,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -129,15 +129,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/viorng/compile.readme
+++ b/viorng/compile.readme
@@ -1,0 +1,15 @@
+The following software must be installed on a build system:
+
+- Microsoft VS12 (VS 2013)
+- Microsoft VDK 8.1
+- Microsoft ADK 8.1
+- Microsoft CNG SDK *note1
+
+*note1:
+- It is require to copy CPDK directory (Cryptographic Provides Developer Kit)
+  to the following path
+	C:\Program Files (x86)\Windows Kits\8.1
+  from
+	C:\Program Files (x86)\Windows Kits\8.0
+  This operations is necessary as by default Visual Studio 12 $WindowsSdkDir
+  points to C:\Program Files (x86)\Windows Kits\8.1


### PR DESCRIPTION
Fix values for memory stats:
    * SWAP_OUT counts as Dirty+Mapped to match with SWAP_IN
    * improve MINFLT stat (as SoftFaults = CopyOnWriteCount + TransitionCount +
                             DemandZeroCount + CacheTransitionCount)
    * improve MAJFLT stat

Some additional information, which may be usefull for Windows guest ballooning:
*https://blogs.technet.microsoft.com/markrussinovich/2009/07/05/pushing-the-limits-of-windows-processes-and-threads/
newly MmResidentAvailablePages is a critical memory counter, its low values prevents apps to run
*MmSharedCommit value is the only source about memory-mapped size
*Filecache stats are vital on Windows for good ballooning, especially Cc...Miss ones.

There is no clean 'pagefile read' counter on Windows.
SWAP_IN uses PageReadCount counter, which includes reads from pagefile,
reads from memory-mapped files (both cached and non-cached) and
prefetching reads (including superfetch).

So SWAP_OUT should include mapped writes as well as dirty writes.
Then these two counters are 'matched by sources'.

This is not mention at MSDN, so here is a brief research report
as a proof (w2k12r2):
PageReadIoCout/PageReadCount are updated in MiWaitForInPageComplete,
which is called both from MiIssueHardFault and MiPfCompletePrefetchIos.
Last one is called from MiPrefetchVirtualMemory,
MmWaitForCacheManagerPrefetch, MiPrefetchControlArea and MmPrefetchPages.

PageFaultCount is incremented in MiAllocateWsle,
i.e. every time a physical page is mapped to a virtual address, using
working set. Actually this is invplg count, not #PF count.

Following formulas show what we can count:
* SoftFaults = CopyOnWriteCount + TransitionCount +
               DemandZeroCount + CacheTransitionCount
* PageReadCount = HardFaults + Prefetch, and we cannot separate them. But we
    can point, that without prefetching most of theese pages will trigger hard
    fault (based on assumption that prefetching doesn't make too much
    unnessessary reads)
* PageFaultCount - SoftFaults = PageReadCount + WsleAllocations.
    at least WsleAllocations includes some PageTables allocations
    and some kernel stack allocations.

That's why we should use PageReadCount as MAJFLT, not PageReadIoCount.
First value can be compared with similar fault counters, while the second
measures number of times the disk was read to resolve hard page faults and
during prefetching. Due to async processing and coalescing this value
doesn't correspond with anything.

Alexey V. Kostyushko (2):
  Balloon: force SWAP_OUT to match SWAP_IN
  Balloon: improve MINFLT and MAJFLT stats values

 Balloon/sys/memstat.c | 16 ++++++++++++----
 1 file changed, 12 insertions(+), 4 deletions(-)