### PR TITLE
virtiorng: replace obsolete CNG SDK with CPDK

### DIFF
--- a/viorng/cng/um/viorngum.c
+++ b/viorng/cng/um/viorngum.c
@@ -24,6 +24,8 @@
 
 #define STRICT
 #include <windows.h>
+#include <bcrypt.h>
+#include <bcrypt_provider.h>
 #include <initguid.h>
 #include <setupapi.h>
 #include <tchar.h>

--- a/viorng/cng/um/viorngum.vcxproj
+++ b/viorng/cng/um/viorngum.vcxproj
@@ -101,7 +101,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -120,7 +120,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -141,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -164,7 +164,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;VIORNGPROV_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/viorng/coinstaller/viorngci.c
+++ b/viorng/coinstaller/viorngci.c
@@ -25,6 +25,7 @@
 #define STRICT
 #include <windows.h>
 #include <bcrypt.h>
+#include <bcrypt_provider.h>
 #include <setupapi.h>
 #include <tchar.h>
 

--- a/viorng/coinstaller/viorngci.vcxproj
+++ b/viorng/coinstaller/viorngci.vcxproj
@@ -78,13 +78,13 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -93,13 +93,13 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -110,15 +110,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -129,15 +129,15 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(MSBuildProgramFiles32)\Microsoft CNG Development Kit\Lib\$(PlatformTarget)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(WindowsSdkDir)\Cryptographic Provider Development Kit\Lib\win8\$(PlatformTarget)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>bcrypt_provider.lib;bcrypt.lib;setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>viorngci.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/viorng/compile.readme
+++ b/viorng/compile.readme
@@ -1,0 +1,11 @@
+For successfull compilation the next tools needed to be installed on system:
+
+- Microsoft VS12 (VS 2013)
+- Microsoft VDK 8.1
+- Microsoft ADK 8.1
+- Microsoft CNG SDK *note1
+
+*note1:
+- After CPDK installation you need to copy the CPDK dir (Cryptographic Provides Developer Kit)
+to C:\Program Files (x86)\Windows Kits\8.1 from C:\Program Files (x86)\Windows Kits\8.0
+Because by default VS12 $WindowsSdkDir points to C:\Program Files (x86)\Windows Kits\8.1


### PR DESCRIPTION
CNG SDK is no longer available on microsoft.com, claimed as obsolete.
It is replaced by CPDK - Cryptographic Provider Development Kit

compile.readme is added about required build environment and
resolving of possible minor CPDK installation location issue

Signed-off-by: Alexey V. Kostyushko <aleksko@virtuozzo.com>$
Signed-off-by: Denis V. Lunev <den@openvz.org>