### PR TITLE
fix : missing key when inputing combination keys

### DIFF
--- a/vioinput/sys/Device.c
+++ b/vioinput/sys/Device.c
@@ -104,7 +104,6 @@ VIOInputEvtDeviceAdd(
 
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attributes, INPUT_DEVICE);
     Attributes.SynchronizationScope = WdfSynchronizationScopeDevice;
-    //Attributes.ExecutionLevel = WdfExecutionLevelPassive;
     status = WdfDeviceCreate(&DeviceInit, &Attributes, &hDevice);
     if (!NT_SUCCESS(status))
     {

--- a/vioinput/sys/Device.c
+++ b/vioinput/sys/Device.c
@@ -104,7 +104,7 @@ VIOInputEvtDeviceAdd(
 
     WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&Attributes, INPUT_DEVICE);
     Attributes.SynchronizationScope = WdfSynchronizationScopeDevice;
-    Attributes.ExecutionLevel = WdfExecutionLevelPassive;
+    //Attributes.ExecutionLevel = WdfExecutionLevelPassive;
     status = WdfDeviceCreate(&DeviceInit, &Attributes, &hDevice);
     if (!NT_SUCCESS(status))
     {


### PR DESCRIPTION
When HidQueue's ExecutionLevel= WdfExecutionLevelPassive and WdfIoQueueRetrieveNextRequest is called in IRQL=
DISPATCH ,so WdfRequestForwardToIoQueue(in hid.c EvtIoDeviceControl)can not be called timely for inserting request to HIdQueue.